### PR TITLE
Some optimizations 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
 
 [profile.release]
 lto = true
+codegen-units = 1
 
 [workspace.dependencies]
 bpaf = "0.7.3"

--- a/frost/src/lib.rs
+++ b/frost/src/lib.rs
@@ -70,12 +70,14 @@ impl OpCode {
     }
 }
 
+#[inline(always)]
 fn read_le_u32(reader: &mut impl Read) -> io::Result<u32> {
     let mut len_buf = [0u8; 4];
     reader.read_exact(&mut len_buf)?;
     Ok(u32::from_le_bytes(len_buf))
 }
 
+#[inline(always)]
 fn field_sep_index(buf: &[u8]) -> Result<usize, Error> {
     buf.iter().position(|&b| b == b'=').ok_or_else(|| {
         Error::new(ErrorKind::InvalidBag(Cow::Borrowed(
@@ -84,6 +86,7 @@ fn field_sep_index(buf: &[u8]) -> Result<usize, Error> {
     })
 }
 
+#[inline(always)]
 fn parse_field(buf: &[u8], i: usize) -> Result<(usize, &[u8], &[u8]), Error> {
     let mut i = i;
     let field_len = util::parsing::parse_le_u32_at(buf, i)? as usize;
@@ -997,6 +1000,7 @@ impl<R: Read + Seek> Bag<R> {
     }
 }
 
+#[inline(always)]
 fn read_header_op(buf: &[u8]) -> Result<OpCode, Error> {
     let mut i = 0;
     loop {

--- a/frost/src/util/parsing.rs
+++ b/frost/src/util/parsing.rs
@@ -1,9 +1,11 @@
 use std::io::{self, Read};
 
+#[inline(always)]
 pub fn parse_u8(buf: &[u8]) -> io::Result<u8> {
     parse_u8_at(buf, 0)
 }
 
+#[inline(always)]
 pub fn parse_u8_at(buf: &[u8], index: usize) -> io::Result<u8> {
     let bytes = buf.get(index..index + 1).ok_or_else(|| {
         io::Error::new(
@@ -14,10 +16,12 @@ pub fn parse_u8_at(buf: &[u8], index: usize) -> io::Result<u8> {
     Ok(u8::from_le_bytes(bytes.try_into().unwrap()))
 }
 
+#[inline(always)]
 pub fn parse_le_u32(buf: &[u8]) -> io::Result<u32> {
     parse_le_u32_at(buf, 0)
 }
 
+#[inline(always)]
 pub fn parse_le_u32_at(buf: &[u8], index: usize) -> io::Result<u32> {
     let bytes = buf.get(index..index + 4).ok_or_else(|| {
         io::Error::new(
@@ -28,10 +32,12 @@ pub fn parse_le_u32_at(buf: &[u8], index: usize) -> io::Result<u32> {
     Ok(u32::from_le_bytes(bytes.try_into().unwrap()))
 }
 
+#[inline(always)]
 pub fn parse_le_u64(buf: &[u8]) -> io::Result<u64> {
     parse_le_u64_at(buf, 0)
 }
 
+#[inline(always)]
 pub fn parse_le_u64_at(buf: &[u8], index: usize) -> io::Result<u64> {
     let bytes = buf.get(index..index + 8).ok_or_else(|| {
         io::Error::new(
@@ -42,6 +48,7 @@ pub fn parse_le_u64_at(buf: &[u8], index: usize) -> io::Result<u64> {
     Ok(u64::from_le_bytes(bytes.try_into().unwrap()))
 }
 
+#[inline(always)]
 pub fn get_lengthed_bytes(reader: &mut impl Read) -> io::Result<Vec<u8>> {
     // Get a vector of bytes from a reader when the first 4 bytes are the length
     // Ex: with <header_len><header> or <data_len><data>, this function returns either header or data


### PR DESCRIPTION
This PR reduces codegen units to 1, and adds some inlines. Overall, it's about close to a 20% speedup. Overall binary size is reduced. 

On a linux desktop:
```bash
frost$ hyperfine --warmup 3 "./target/release/frost_orig info ./frost/tests/fixtures/test_large.bag" "./target/release/frost_cg info ./frost/tests/fixtures/test_large.bag" "./target/release/frost info ./frost/tests/fixtures/test_large.bag"
Benchmark 1: ./target/release/frost_orig info ./frost/tests/fixtures/test_large.bag
  Time (mean ± σ):     658.6 ms ±   1.0 ms    [User: 421.1 ms, System: 237.5 ms]
  Range (min … max):   657.1 ms … 659.7 ms    10 runs
 
Benchmark 2: ./target/release/frost_cg info ./frost/tests/fixtures/test_large.bag
  Time (mean ± σ):     575.9 ms ±   2.6 ms    [User: 334.6 ms, System: 241.3 ms]
  Range (min … max):   573.7 ms … 582.7 ms    10 runs
 
Benchmark 3: ./target/release/frost info ./frost/tests/fixtures/test_large.bag
  Time (mean ± σ):     555.9 ms ±   2.4 ms    [User: 322.2 ms, System: 233.6 ms]
  Range (min … max):   552.8 ms … 558.5 ms    10 runs
 
Summary
  './target/release/frost info ./frost/tests/fixtures/test_large.bag' ran
    1.04 ± 0.01 times faster than './target/release/frost_cg info ./frost/tests/fixtures/test_large.bag'
    1.18 ± 0.01 times faster than './target/release/frost_orig info ./frost/tests/fixtures/test_large.bag'
```

On a macbook:
```bash
Benchmark 1: ./target/release/frost_orig info ./frost/tests/fixtures/decompressed_large.bag
  Time (mean ± σ):      1.212 s ±  0.051 s    [User: 0.753 s, System: 0.456 s]
  Range (min … max):    1.144 s …  1.281 s    10 runs

Benchmark 2: ./target/release/frost_cg info ./frost/tests/fixtures/decompressed_large.bag
  Time (mean ± σ):      1.016 s ±  0.042 s    [User: 0.578 s, System: 0.435 s]
  Range (min … max):    0.969 s …  1.092 s    10 runs

Benchmark 3: ./target/release/frost info ./frost/tests/fixtures/decompressed_large.bag
  Time (mean ± σ):      1.001 s ±  0.056 s    [User: 0.569 s, System: 0.430 s]
  Range (min … max):    0.899 s …  1.107 s    10 runs

Summary
  './target/release/frost info ./frost/tests/fixtures/decompressed_large.bag' ran
    1.01 ± 0.07 times faster than './target/release/frost_cg info ./frost/tests/fixtures/decompressed_large.bag'
    1.21 ± 0.08 times faster than './target/release/frost_orig info ./frost/tests/fixtures/decompressed_large.bag'
```