### PR TITLE
Add types filter to Queries 

### DIFF
--- a/examples/read_bag/src/main.rs
+++ b/examples/read_bag/src/main.rs
@@ -53,6 +53,14 @@ fn main() {
     let msg = msg_view.instantiate::<std_msgs::String>().unwrap();
     println!("Last {} message is {}", &msg_view.topic, msg.data);
 
+    let query = Query::new().with_types(&["std_msgs/Float64MultiArray"]);
+    let count = bag.read_messages(&query).unwrap().count();
+    assert_eq!(count, 100);
+    println!(
+        "There are {} messages with type {}",
+        count, "std_msgs/Float64MultiArray"
+    );
+
     // check msg constants (type not in bag)
     assert_eq!(dummy_msgs::Dummy::PI, PI);
     assert_eq!(dummy_msgs::Dummy::N_PI, -PI);

--- a/frost/src/bin/frost.rs
+++ b/frost/src/bin/frost.rs
@@ -187,6 +187,9 @@ fn print_all(
     }
 
     let max_topic_len = max_topic_len(bag);
+
+    let topic_counts = bag.topic_message_counts();
+
     for (i, (topic, data_type)) in bag
         .topics_and_types()
         .into_iter()
@@ -194,7 +197,7 @@ fn print_all(
         .enumerate()
     {
         let col_display = if i == 0 { "topics:" } else { "" };
-        let msg_count = bag.topic_message_count(topic).unwrap_or(0);
+        let msg_count = topic_counts.get(topic).unwrap_or(&0);
         writer.write_all(
             format!(
                 "{0: <13}{1: <max_topic_len$} {2:>10} msgs : {3}\n",

--- a/frost/src/lib.rs
+++ b/frost/src/lib.rs
@@ -717,13 +717,18 @@ impl<R: Read + Seek> Bag<R> {
 
     pub fn topic_message_counts(&self) -> BTreeMap<String, usize> {
         let topic_to_ids = self.topic_to_connection_ids();
-        topic_to_ids.iter().map(|(topic, conn_ids)| {
-            (topic.clone(), 
-            conn_ids
-                .iter()
-                .map(|id| self.index_data.get(id).map_or_else(|| 0, |data| data.len()))
-                .sum())
-        }).collect()
+        topic_to_ids
+            .iter()
+            .map(|(topic, conn_ids)| {
+                (
+                    topic.clone(),
+                    conn_ids
+                        .iter()
+                        .map(|id| self.index_data.get(id).map_or_else(|| 0, |data| data.len()))
+                        .sum(),
+                )
+            })
+            .collect()
     }
 
     pub fn compression_info(&self) -> Vec<CompressionInfo> {

--- a/frost/src/lib.rs
+++ b/frost/src/lib.rs
@@ -715,13 +715,15 @@ impl<R: Read + Seek> Bag<R> {
         self.index_data.values().map(|v| v.len()).sum()
     }
 
-    pub fn topic_message_count(&self, topic: &str) -> Option<usize> {
-        self.topic_to_connection_ids().get(topic).map(|conn_ids| {
+    pub fn topic_message_counts(&self) -> BTreeMap<String, usize> {
+        let topic_to_ids = self.topic_to_connection_ids();
+        topic_to_ids.iter().map(|(topic, conn_ids)| {
+            (topic.clone(), 
             conn_ids
                 .iter()
                 .map(|id| self.index_data.get(id).map_or_else(|| 0, |data| data.len()))
-                .sum()
-        })
+                .sum())
+        }).collect()
     }
 
     pub fn compression_info(&self) -> Vec<CompressionInfo> {

--- a/frost/src/lib.rs
+++ b/frost/src/lib.rs
@@ -30,7 +30,6 @@ pub struct Bag<R: Read + Seek> {
     pub(crate) chunk_bytes: BTreeMap<ChunkHeaderLoc, Vec<u8>>,
     pub connection_data: BTreeMap<ConnectionID, ConnectionData>,
     pub(crate) index_data: BTreeMap<ConnectionID, Vec<IndexData>>,
-    topic_to_connection_ids: BTreeMap<String, Vec<ConnectionID>>,
     pub size: u64,
 }
 
@@ -657,16 +656,6 @@ impl<R: Read + Seek> Bag<R> {
 
         let (chunk_metadata, connection_data, index_data) = Bag::parse_records(&mut reader)?;
 
-        let topic_to_ids: BTreeMap<String, Vec<ConnectionID>> =
-            connection_data
-                .values()
-                .fold(BTreeMap::new(), |mut acc, data| {
-                    acc.entry(data.topic.clone())
-                        .or_default()
-                        .push(data.connection_id);
-                    acc
-                });
-
         Ok(Bag {
             version,
             file_path: None,
@@ -675,9 +664,30 @@ impl<R: Read + Seek> Bag<R> {
             chunk_bytes: BTreeMap::new(),
             connection_data,
             index_data,
-            topic_to_connection_ids: topic_to_ids,
             size: 0, // will be set in constructor
         })
+    }
+
+    fn topic_to_connection_ids(&self) -> BTreeMap<String, Vec<ConnectionID>> {
+        self.connection_data
+            .values()
+            .fold(BTreeMap::new(), |mut acc, data| {
+                acc.entry(data.topic.clone())
+                    .or_default()
+                    .push(data.connection_id);
+                acc
+            })
+    }
+
+    fn type_to_connection_ids(&self) -> BTreeMap<String, Vec<ConnectionID>> {
+        self.connection_data
+            .values()
+            .fold(BTreeMap::new(), |mut acc, data| {
+                acc.entry(data.data_type.clone())
+                    .or_default()
+                    .push(data.connection_id);
+                acc
+            })
     }
 
     pub fn read_messages(&mut self, query: &Query) -> Result<BagIter<R>, Error> {
@@ -706,7 +716,7 @@ impl<R: Read + Seek> Bag<R> {
     }
 
     pub fn topic_message_count(&self, topic: &str) -> Option<usize> {
-        self.topic_to_connection_ids.get(topic).map(|conn_ids| {
+        self.topic_to_connection_ids().get(topic).map(|conn_ids| {
             conn_ids
                 .iter()
                 .map(|id| self.index_data.get(id).map_or_else(|| 0, |data| data.len()))
@@ -736,8 +746,12 @@ impl<R: Read + Seek> Bag<R> {
             .collect()
     }
 
-    pub fn topics(&self) -> Vec<&String> {
-        self.topic_to_connection_ids.keys().collect()
+    pub fn topics(&self) -> Vec<&str> {
+        self.connection_data
+            .values()
+            .map(|d| d.topic.as_ref())
+            .unique()
+            .collect()
     }
 
     pub fn topics_and_types(&self) -> HashSet<(&String, &String)> {

--- a/frost/tests/test_query.rs
+++ b/frost/tests/test_query.rs
@@ -57,6 +57,35 @@ fn bag_iter_from_bytes() {
         let query = Query::new().with_topics(&["/chatter"]);
         let count = bag.read_messages(&query).unwrap().count();
         assert_eq!(count, 100, "{name}");
+
+        let query = Query::new().with_types(&["std_msgs/String"]);
+        let count = bag.read_messages(&query).unwrap().count();
+        assert_eq!(count, 100, "{name}");
+        bag.read_messages(&query).unwrap().for_each(|msg_view| {
+            assert_eq!(msg_view.topic, "/chatter");
+        });
+
+        let query = Query::new()
+            .with_topics(&["/chatter"])
+            .with_types(&["std_msgs/String"]);
+        let count = bag.read_messages(&query).unwrap().count();
+        assert_eq!(count, 100, "{name}");
+
+        let query = Query::new()
+            .with_topics(&["/time"])
+            .with_types(&["std_msgs/Time"]);
+        let count = bag.read_messages(&query).unwrap().count();
+        assert_eq!(count, 100, "{name}");
+
+        let query = Query::new()
+            .with_topics(&["/chatter"])
+            .with_types(&["std_msgs/Time"]);
+        let count = bag.read_messages(&query).unwrap().count();
+        assert_eq!(count, 0, "{name}");
+
+        let query = Query::new().with_types(&["std_msgs/Time", "std_msgs/String"]);
+        let count = bag.read_messages(&query).unwrap().count();
+        assert_eq!(count, 200, "{name}");
     }
 }
 


### PR DESCRIPTION
Adds a `with_types` filter to the Query api.  Can be used at the same time as `with_topics`

Had to change the topic count api slightly, but there doesn't look to be any visible difference in perf (1.2GB bag)
```
hyperfine --warmup 10 "./target/release/frost-master info frost/tests/fixtures/test_large.bag" "./target/release/frost-types info frost/tests/fixtures/test_large.bag" 
Benchmark 1: ./target/release/frost-master info frost/tests/fixtures/test_large.bag
  Time (mean ± σ):     557.3 ms ±   5.9 ms    [User: 316.0 ms, System: 239.1 ms]
  Range (min … max):   548.5 ms … 564.9 ms    10 runs
 
Benchmark 2: ./target/release/frost-types info frost/tests/fixtures/test_large.bag
  Time (mean ± σ):     554.7 ms ±   3.4 ms    [User: 313.9 ms, System: 240.1 ms]
  Range (min … max):   548.4 ms … 560.3 ms    10 runs

```