### PR TITLE
Decompressed / Owned bag api

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ When using it as a library, code-generation is required to convert ros .msg file
 See the full example and code-generation steps [here](examples/read_bag).
 
 ```rust
-  let mut bag = Bag::from(bag_path).unwrap();
+  let bag = DecompressedBag::from(bag_path).unwrap();
 
   let query = Query::all();
   let count = bag.read_messages(&query).unwrap().count();

--- a/examples/read_bag/src/main.rs
+++ b/examples/read_bag/src/main.rs
@@ -2,7 +2,7 @@ use std::f32::consts::PI;
 use std::{fs::File, io::Write, path::PathBuf};
 
 use frost::query::Query;
-use frost::Bag;
+use frost::DecompressedBag;
 use tempfile::{tempdir, TempDir};
 
 include!(concat!(env!("OUT_DIR"), "/msgs.rs"));
@@ -24,7 +24,7 @@ fn main() {
     let tmp_dir = tempdir().unwrap();
     let bag_path = setup_fixture(&tmp_dir);
 
-    let mut bag = Bag::from(bag_path).unwrap();
+    let mut bag = DecompressedBag::from_file(bag_path).unwrap();
 
     let query = Query::all();
     let count = bag.read_messages(&query).unwrap().count();

--- a/examples/read_bag/src/main.rs
+++ b/examples/read_bag/src/main.rs
@@ -24,7 +24,7 @@ fn main() {
     let tmp_dir = tempdir().unwrap();
     let bag_path = setup_fixture(&tmp_dir);
 
-    let mut bag = DecompressedBag::from_file(bag_path).unwrap();
+    let bag = DecompressedBag::from_file(bag_path).unwrap();
 
     let query = Query::all();
     let count = bag.read_messages(&query).unwrap().count();

--- a/frost/Cargo.toml
+++ b/frost/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frost"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.65"
 build = "build.rs"

--- a/frost/benches/construct.rs
+++ b/frost/benches/construct.rs
@@ -13,8 +13,6 @@ const COMPRESSED_LZ4: &[u8] = include_bytes!("../tests/fixtures/compressed_lz4.b
 #[cfg(all(nightly, test))]
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
-
     use super::*;
     use frost::{query::Query, Bag};
     use test::Bencher;

--- a/frost/benches/construct.rs
+++ b/frost/benches/construct.rs
@@ -30,14 +30,14 @@ mod tests {
     fn bench_from_file(b: &mut Bencher) {
         b.iter(|| {
             for _i in 0..1000 {
-                let mut _bag = hint::black_box(Bag::from(BAG_PATH).unwrap());
+                let mut _bag = hint::black_box(Bag::from_file(BAG_PATH).unwrap());
             }
         });
     }
 
     #[bench]
     fn bench_iterate_from_bytes(b: &mut Bencher) {
-        let mut bag = Bag::from_bytes(COMPRESSED_LZ4).unwrap();
+        let bag = Bag::from_bytes(COMPRESSED_LZ4).unwrap();
         let query = Query::all();
 
         b.iter(|| {
@@ -51,7 +51,7 @@ mod tests {
 
     #[bench]
     fn bench_iterate_from_file(b: &mut Bencher) {
-        let mut bag = Bag::from(BAG_PATH).unwrap();
+        let bag = Bag::from_file(BAG_PATH).unwrap();
         let query = Query::all();
 
         b.iter(|| {

--- a/frost/benches/construct.rs
+++ b/frost/benches/construct.rs
@@ -14,14 +14,14 @@ const COMPRESSED_LZ4: &[u8] = include_bytes!("../tests/fixtures/compressed_lz4.b
 #[cfg(test)]
 mod tests {
     use super::*;
-    use frost::{query::Query, Bag};
+    use frost::{query::Query, BagMetadata};
     use test::Bencher;
 
     #[bench]
     fn bench_from_bytes(b: &mut Bencher) {
         b.iter(|| {
             for _i in 0..1000 {
-                let mut _bag = hint::black_box(Bag::from_bytes(COMPRESSED_LZ4).unwrap());
+                let mut _bag = hint::black_box(BagMetadata::from_bytes(COMPRESSED_LZ4).unwrap());
             }
         });
     }
@@ -30,14 +30,14 @@ mod tests {
     fn bench_from_file(b: &mut Bencher) {
         b.iter(|| {
             for _i in 0..1000 {
-                let mut _bag = hint::black_box(Bag::from_file(BAG_PATH).unwrap());
+                let mut _bag = hint::black_box(BagMetadata::from_file(BAG_PATH).unwrap());
             }
         });
     }
 
     #[bench]
     fn bench_iterate_from_bytes(b: &mut Bencher) {
-        let bag = Bag::from_bytes(COMPRESSED_LZ4).unwrap();
+        let bag = BagMetadata::from_bytes(COMPRESSED_LZ4).unwrap();
         let query = Query::all();
 
         b.iter(|| {
@@ -51,7 +51,7 @@ mod tests {
 
     #[bench]
     fn bench_iterate_from_file(b: &mut Bencher) {
-        let bag = Bag::from_file(BAG_PATH).unwrap();
+        let bag = BagMetadata::from_file(BAG_PATH).unwrap();
         let query = Query::all();
 
         b.iter(|| {

--- a/frost/src/bin/frost.rs
+++ b/frost/src/bin/frost.rs
@@ -43,31 +43,33 @@ fn args() -> Opts {
     parser.to_options().version(env!("CARGO_PKG_VERSION")).run()
 }
 
-fn max_type_len(bag: &BagMetadata) -> usize {
-    bag.connection_data
+fn max_type_len(metadata: &BagMetadata) -> usize {
+    metadata
+        .connection_data
         .values()
         .map(|d| d.data_type.len())
         .max()
         .unwrap_or(0)
 }
 
-fn max_topic_len(bag: &BagMetadata) -> usize {
-    bag.connection_data
+fn max_topic_len(metadata: &BagMetadata) -> usize {
+    metadata
+        .connection_data
         .values()
         .map(|d| d.topic.len())
         .max()
         .unwrap_or(0)
 }
 
-fn print_topics(bag: &BagMetadata, writer: &mut impl Write) -> Result<(), Error> {
-    for topic in bag.topics().into_iter().sorted() {
+fn print_topics(metadata: &BagMetadata, writer: &mut impl Write) -> Result<(), Error> {
+    for topic in metadata.topics().into_iter().sorted() {
         writer.write_all(format!("{topic}\n").as_bytes())?
     }
     Ok(())
 }
 
-fn print_types(bag: &BagMetadata, writer: &mut impl Write) -> Result<(), Error> {
-    for topic in bag.types().into_iter().sorted() {
+fn print_types(metadata: &BagMetadata, writer: &mut impl Write) -> Result<(), Error> {
+    for topic in metadata.types().into_iter().sorted() {
         writer.write_all(format!("{topic}\n").as_bytes())?
     }
     Ok(())
@@ -94,23 +96,31 @@ fn human_bytes(bytes: u64) -> String {
     }
 }
 
-fn print_all(bag: &BagMetadata, minimal: bool, writer: &mut impl Write) -> Result<(), Error> {
-    let start_time = bag.start_time().expect("Bag does not have a start time");
-    let end_time = bag.end_time().expect("Bag does not have a end time");
+fn print_all(metadata: &BagMetadata, minimal: bool, writer: &mut impl Write) -> Result<(), Error> {
+    let start_time = metadata
+        .start_time()
+        .expect("Bag does not have a start time");
+    let end_time = metadata.end_time().expect("Bag does not have a end time");
 
     writer.write_all(
         format!(
             "{0: <13}{1}\n",
             "path:",
-            bag.file_path
+            metadata
+                .file_path
                 .as_ref()
                 .map_or_else(|| "None".to_string(), |p| p.to_string_lossy().into_owned())
         )
         .as_bytes(),
     )?;
-    writer.write_all(format!("{0: <13}{1}\n", "version:", bag.version).as_bytes())?;
+    writer.write_all(format!("{0: <13}{1}\n", "version:", metadata.version).as_bytes())?;
     writer.write_all(
-        format!("{0: <13}{1:.2}s\n", "duration:", bag.duration().as_secs()).as_bytes(),
+        format!(
+            "{0: <13}{1:.2}s\n",
+            "duration:",
+            metadata.duration().as_secs()
+        )
+        .as_bytes(),
     )?;
     writer.write_all(
         format!(
@@ -131,11 +141,11 @@ fn print_all(bag: &BagMetadata, minimal: bool, writer: &mut impl Write) -> Resul
         .as_bytes(),
     )?;
 
-    writer.write_all(format!("{0: <13}{1}\n", "size:", human_bytes(bag.size)).as_bytes())?;
+    writer.write_all(format!("{0: <13}{1}\n", "size:", human_bytes(metadata.size)).as_bytes())?;
 
-    writer.write_all(format!("{0: <13}{1}\n", "messages:", bag.message_count()).as_bytes())?;
+    writer.write_all(format!("{0: <13}{1}\n", "messages:", metadata.message_count()).as_bytes())?;
 
-    let compression_info = bag.compression_info();
+    let compression_info = metadata.compression_info();
 
     let total_chunks: usize = compression_info.iter().map(|info| info.chunk_count).sum();
     let max_compression_name = compression_info
@@ -162,8 +172,8 @@ fn print_all(bag: &BagMetadata, minimal: bool, writer: &mut impl Write) -> Resul
         return Ok(());
     }
 
-    let max_type_len = max_type_len(bag);
-    for (i, (data_type, md5sum)) in bag
+    let max_type_len = max_type_len(metadata);
+    for (i, (data_type, md5sum)) in metadata
         .connection_data
         .values()
         .map(|data| (data.data_type.clone(), data.md5sum.clone()))
@@ -182,11 +192,11 @@ fn print_all(bag: &BagMetadata, minimal: bool, writer: &mut impl Write) -> Resul
         )?;
     }
 
-    let max_topic_len = max_topic_len(bag);
+    let max_topic_len = max_topic_len(metadata);
 
-    let topic_counts = bag.topic_message_counts();
+    let topic_counts = metadata.topic_message_counts();
 
-    for (i, (topic, data_type)) in bag
+    for (i, (topic, data_type)) in metadata
         .topics_and_types()
         .into_iter()
         .sorted_by(|a, b| Ord::cmp(&a.0, &b.0))

--- a/frost/src/bin/frost.rs
+++ b/frost/src/bin/frost.rs
@@ -218,15 +218,15 @@ fn main() -> Result<(), Error> {
 
     match args {
         Opts::TopicOptions { file_path } => {
-            let bag = Bag::from(file_path)?;
+            let bag = Bag::from_file(file_path)?;
             print_topics(&bag, &mut writer)
         }
         Opts::InfoOptions { minimal, file_path } => {
-            let bag = Bag::from(file_path)?;
+            let bag = Bag::from_file(file_path)?;
             print_all(&bag, minimal, &mut writer)
         }
         Opts::TypeOptions { file_path } => {
-            let bag = Bag::from(file_path)?;
+            let bag = Bag::from_file(file_path)?;
             print_types(&bag, &mut writer)
         }
     }

--- a/frost/src/bin/frost.rs
+++ b/frost/src/bin/frost.rs
@@ -224,16 +224,16 @@ fn main() -> Result<(), Error> {
 
     match args {
         Opts::TopicOptions { file_path } => {
-            let bag = BagMetadata::from_file(file_path)?;
-            print_topics(&bag, &mut writer)
+            let metadata = BagMetadata::from_file(file_path)?;
+            print_topics(&metadata, &mut writer)
         }
         Opts::InfoOptions { minimal, file_path } => {
-            let bag = BagMetadata::from_file(file_path)?;
-            print_all(&bag, minimal, &mut writer)
+            let metadata = BagMetadata::from_file(file_path)?;
+            print_all(&metadata, minimal, &mut writer)
         }
         Opts::TypeOptions { file_path } => {
-            let bag = BagMetadata::from_file(file_path)?;
-            print_types(&bag, &mut writer)
+            let metadata = BagMetadata::from_file(file_path)?;
+            print_types(&metadata, &mut writer)
         }
     }
 }

--- a/frost/src/lib.rs
+++ b/frost/src/lib.rs
@@ -1079,7 +1079,7 @@ impl DecompressedBag {
         Ok(bag)
     }
 
-    pub fn read_messages(& self, query: &Query) -> Result<BagIter, Error> {
+    pub fn read_messages(&self, query: &Query) -> Result<BagIter, Error> {
         BagIter::new(self, query)
     }
 

--- a/frost/src/util/msgs.rs
+++ b/frost/src/util/msgs.rs
@@ -5,7 +5,7 @@ use serde::de;
 use serde_rosmsg;
 
 use crate::errors::{Error, ErrorKind};
-use crate::{DecompressedBag, ChunkHeaderLoc};
+use crate::{ChunkHeaderLoc, DecompressedBag};
 
 pub trait Msg {}
 

--- a/frost/src/util/msgs.rs
+++ b/frost/src/util/msgs.rs
@@ -42,6 +42,6 @@ impl<'a> MessageView<'a> {
         T: Msg,
         T: de::Deserialize<'de>,
     {
-        serde_rosmsg::from_slice(&self.raw_bytes()?).map_err(|e| e.into())
+        serde_rosmsg::from_slice(self.raw_bytes()?).map_err(|e| e.into())
     }
 }

--- a/frost/src/util/msgs.rs
+++ b/frost/src/util/msgs.rs
@@ -1,24 +1,23 @@
 use std::borrow::Cow;
-use std::io::{Read, Seek};
 
 use serde;
 use serde::de;
 use serde_rosmsg;
 
 use crate::errors::{Error, ErrorKind};
-use crate::{Bag, ChunkHeaderLoc};
+use crate::{DecompressedBag, ChunkHeaderLoc};
 
 pub trait Msg {}
 
-pub struct MessageView<'a, R: Read + Seek> {
+pub struct MessageView<'a> {
     pub topic: &'a str,
-    pub(crate) bag: &'a Bag<R>,
+    pub(crate) bag: &'a DecompressedBag,
     pub(crate) chunk_loc: ChunkHeaderLoc,
     pub(crate) start_index: usize,
     pub(crate) end_index: usize,
 }
 
-impl<'a, R: Read + Seek> MessageView<'a, R> {
+impl<'a> MessageView<'a> {
     /// Returns the raw bytes of the entire Chunk that holds the message
     fn chunk_bytes(&self) -> Result<&'a [u8], Error> {
         self.bag

--- a/frost/src/util/query.rs
+++ b/frost/src/util/query.rs
@@ -67,7 +67,7 @@ pub struct BagIter<'a> {
 }
 impl<'a> BagIter<'a> {
     pub(crate) fn new(bag: &'a DecompressedBag, query: &Query) -> Result<Self, Error> {
-        let topic_to_connection_ids = bag.topic_to_connection_ids();
+        let topic_to_connection_ids = bag.metadata.topic_to_connection_ids();
         let ids_from_topics: HashSet<ConnectionID> = match &query.topics {
             Some(topics) => topics
                 .iter()
@@ -80,7 +80,7 @@ impl<'a> BagIter<'a> {
                 .cloned()
                 .collect(),
         };
-        let types_to_connection_ids = bag.type_to_connection_ids();
+        let types_to_connection_ids = bag.metadata.type_to_connection_ids();
         let ids_from_types: HashSet<ConnectionID> = match &query.types {
             Some(types) => types
                 .iter()
@@ -99,7 +99,7 @@ impl<'a> BagIter<'a> {
             .collect();
         let mut index_data: Vec<IndexData> = ids
             .iter()
-            .flat_map(|id| bag.index_data.get(id).unwrap().clone())
+            .flat_map(|id| bag.metadata.index_data.get(id).unwrap().clone())
             .filter(|data| {
                 if let Some(start_time) = query.start_time {
                     if data.time < start_time {
@@ -133,7 +133,13 @@ impl<'a> Iterator for BagIter<'a> {
         } else {
             let data = self.index_data.get(self.current_index)?;
 
-            let topic = &self.bag.connection_data.get(&data.conn_id).unwrap().topic;
+            let topic = &self
+                .bag
+                .metadata
+                .connection_data
+                .get(&data.conn_id)
+                .unwrap()
+                .topic;
 
             let chunk_bytes = self.bag.chunk_bytes.get(&data.chunk_header_pos)?;
 

--- a/frost/src/util/query.rs
+++ b/frost/src/util/query.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use crate::errors::Error;
 use crate::time::Time;
-use crate::{DecompressedBag, ConnectionID, IndexData, MessageDataHeader};
+use crate::{ConnectionID, DecompressedBag, IndexData, MessageDataHeader};
 
 use super::{msgs::MessageView, parsing::parse_le_u32_at};
 
@@ -115,7 +115,6 @@ impl<'a> BagIter<'a> {
             })
             .collect();
         index_data.sort_by(|a, b| a.time.cmp(&b.time));
-
 
         Ok(BagIter {
             bag,

--- a/frost/tests/test_query.rs
+++ b/frost/tests/test_query.rs
@@ -1,7 +1,7 @@
 use std::{fs::File, io::Write, path::PathBuf};
 
-use frost::Bag;
 use frost::query::Query;
+use frost::Bag;
 use frost::{errors::ErrorKind, DecompressedBag};
 
 use tempfile::{tempdir, TempDir};

--- a/frost/tests/test_query.rs
+++ b/frost/tests/test_query.rs
@@ -1,6 +1,6 @@
 use std::{fs::File, io::Write, path::PathBuf};
 
-use frost::errors::ErrorKind;
+use frost::{errors::ErrorKind, DecompressedBag};
 use frost::query::Query;
 use frost::Bag;
 
@@ -31,7 +31,7 @@ fn bag_iter_from_file() {
     .iter()
     {
         let (_tmp_dir, file_path) = write_test_fixture(bytes);
-        let mut bag = Bag::from(file_path).unwrap();
+        let mut bag = DecompressedBag::from_file(file_path).unwrap();
 
         let query = Query::all();
         let count = bag.read_messages(&query).unwrap().count();
@@ -51,7 +51,7 @@ fn bag_iter_from_bytes() {
     ]
     .iter()
     {
-        let mut bag = Bag::from_bytes(bytes).unwrap();
+        let mut bag = DecompressedBag::from_bytes(bytes.to_vec()).unwrap();
 
         let query = Query::all();
         let count = bag.read_messages(&query).unwrap().count();
@@ -104,7 +104,7 @@ fn msg_reading() {
     ]
     .iter()
     {
-        let mut bag = Bag::from_bytes(bytes).unwrap();
+        let mut bag = DecompressedBag::from_bytes(bytes.to_vec()).unwrap();
 
         let query = Query::new().with_topics(&["/chatter"]);
 
@@ -143,7 +143,7 @@ fn msg_reading_wrong_type() {
     ]
     .iter()
     {
-        let mut bag = Bag::from_bytes(bytes).unwrap();
+        let mut bag = DecompressedBag::from_bytes(bytes.to_vec()).unwrap();
 
         let query = Query::new().with_topics(&["/chatter"]);
         let msg_view = bag.read_messages(&query).unwrap().last().unwrap();

--- a/frost/tests/test_query.rs
+++ b/frost/tests/test_query.rs
@@ -1,8 +1,7 @@
 use std::{fs::File, io::Write, path::PathBuf};
 
-use frost::{errors::ErrorKind, DecompressedBag};
 use frost::query::Query;
-use frost::Bag;
+use frost::{errors::ErrorKind, DecompressedBag};
 
 use tempfile::{tempdir, TempDir};
 

--- a/frost/tests/test_query.rs
+++ b/frost/tests/test_query.rs
@@ -1,7 +1,7 @@
 use std::{fs::File, io::Write, path::PathBuf};
 
 use frost::query::Query;
-use frost::BagMetadata;
+
 use frost::{errors::ErrorKind, DecompressedBag};
 
 use tempfile::{tempdir, TempDir};

--- a/frost/tests/test_query.rs
+++ b/frost/tests/test_query.rs
@@ -1,7 +1,7 @@
 use std::{fs::File, io::Write, path::PathBuf};
 
 use frost::query::Query;
-use frost::Bag;
+use frost::BagMetadata;
 use frost::{errors::ErrorKind, DecompressedBag};
 
 use tempfile::{tempdir, TempDir};
@@ -32,28 +32,6 @@ fn bag_iter_from_file() {
     {
         let (_tmp_dir, file_path) = write_test_fixture(bytes);
         let bag = DecompressedBag::from_file(file_path).unwrap();
-
-        let query = Query::all();
-        let count = bag.read_messages(&query).unwrap().count();
-        assert_eq!(count, 300, "{name}");
-
-        let query = Query::new().with_topics(&["/chatter"]);
-        let count = bag.read_messages(&query).unwrap().count();
-        assert_eq!(count, 100, "{name}");
-    }
-}
-
-#[test]
-fn bag_iter_from_file_decompression() {
-    for (bytes, name) in [
-        (DECOMPRESSED, "decompressed"),
-        (COMPRESSED_LZ4, "compressed_lz4"),
-    ]
-    .iter()
-    {
-        let (_tmp_dir, file_path) = write_test_fixture(bytes);
-        let bag = Bag::from_file(file_path).unwrap();
-        let bag = bag.decompress().unwrap();
 
         let query = Query::all();
         let count = bag.read_messages(&query).unwrap().count();


### PR DESCRIPTION
The api for iterating messages no longer exists on the `Bag` type as it is now done in the `DecompressedBag` type. This new type owns the data (and also decompresses it), so `read_messages` no longer requires a mutable reference to self. 
This has the benefit of allowing the same bag to be iterated by multiple threads.

Additionally, the `Bag` type has been renamed `BagMetadata`. Constructing this type is useful when you don't need to read the messages, for example, in the `frost` cli. It is also a public member of the `DecompressedBag` struct. 