### PR TITLE
Unit variant errors in the hot loop

### DIFF
--- a/frost/Cargo.toml
+++ b/frost/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frost"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 rust-version = "1.65"
 build = "build.rs"

--- a/frost/benches/construct.rs
+++ b/frost/benches/construct.rs
@@ -14,14 +14,15 @@ const COMPRESSED_LZ4: &[u8] = include_bytes!("../tests/fixtures/compressed_lz4.b
 #[cfg(test)]
 mod tests {
     use super::*;
-    use frost::{query::Query, BagMetadata};
+    use frost::{query::Query, DecompressedBag};
     use test::Bencher;
 
     #[bench]
     fn bench_from_bytes(b: &mut Bencher) {
         b.iter(|| {
             for _i in 0..1000 {
-                let mut _bag = hint::black_box(BagMetadata::from_bytes(COMPRESSED_LZ4).unwrap());
+                let mut _bag =
+                    hint::black_box(DecompressedBag::from_bytes(COMPRESSED_LZ4).unwrap());
             }
         });
     }
@@ -30,14 +31,14 @@ mod tests {
     fn bench_from_file(b: &mut Bencher) {
         b.iter(|| {
             for _i in 0..1000 {
-                let mut _bag = hint::black_box(BagMetadata::from_file(BAG_PATH).unwrap());
+                let mut _bag = hint::black_box(DecompressedBag::from_file(BAG_PATH).unwrap());
             }
         });
     }
 
     #[bench]
     fn bench_iterate_from_bytes(b: &mut Bencher) {
-        let bag = BagMetadata::from_bytes(COMPRESSED_LZ4).unwrap();
+        let bag = DecompressedBag::from_bytes(COMPRESSED_LZ4).unwrap();
         let query = Query::all();
 
         b.iter(|| {
@@ -51,7 +52,7 @@ mod tests {
 
     #[bench]
     fn bench_iterate_from_file(b: &mut Bencher) {
-        let bag = BagMetadata::from_file(BAG_PATH).unwrap();
+        let bag = DecompressedBag::from_file(BAG_PATH).unwrap();
         let query = Query::all();
 
         b.iter(|| {

--- a/frost/src/errors.rs
+++ b/frost/src/errors.rs
@@ -24,6 +24,7 @@ pub enum ErrorKind {
     Deserialization(serde_rosmsg::Error),
     Decompression(lz4_flex::block::DecompressError),
     Io(io::Error),
+    Parse(ParseError),
 }
 
 impl fmt::Display for Error {
@@ -37,6 +38,7 @@ impl fmt::Display for Error {
             ErrorKind::InvalidBag(ref cow) => write!(f, "invalid bag: {cow}"),
             ErrorKind::Deserialization(ref e) => e.fmt(f),
             ErrorKind::Decompression(ref e) => e.fmt(f),
+            ErrorKind::Parse(ref e) => e.fmt(f),
         }
     }
 }
@@ -66,3 +68,33 @@ impl From<lz4_flex::block::DecompressError> for Error {
         }
     }
 }
+
+impl From<ParseError> for Error {
+    fn from(e: ParseError) -> Error {
+        Error {
+            kind: ErrorKind::Parse(e),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ParseError {
+    MissingChunkInfoData,
+    MissingIndexData,
+    MissingFieldSeparator,
+    MissingHeaderOp,
+    InvalidOpCode,
+    BufferTooSmall,
+    UnexpectedField,
+    UnexpectedOpCode,
+    MissingField,
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Implement display logic
+        write!(f, "Custom error: {:?}", self)
+    }
+}
+
+impl std::error::Error for ParseError {}

--- a/frost/src/errors.rs
+++ b/frost/src/errors.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::error;
 use std::fmt;
 use std::io;
@@ -19,8 +18,6 @@ impl Error {
 #[derive(Debug)]
 pub enum ErrorKind {
     NotARosbag,
-    UnindexedBag,
-    InvalidBag(Cow<'static, str>),
     Deserialization(serde_rosmsg::Error),
     Decompression(lz4_flex::block::DecompressError),
     Io(io::Error),
@@ -34,8 +31,6 @@ impl fmt::Display for Error {
                 write!(f, "invalid rosbag v2 header")
             }
             ErrorKind::Io(ref e) => e.fmt(f),
-            ErrorKind::UnindexedBag => write!(f, "unindexed bag"),
-            ErrorKind::InvalidBag(ref cow) => write!(f, "invalid bag: {cow}"),
             ErrorKind::Deserialization(ref e) => e.fmt(f),
             ErrorKind::Decompression(ref e) => e.fmt(f),
             ErrorKind::Parse(ref e) => e.fmt(f),
@@ -79,15 +74,17 @@ impl From<ParseError> for Error {
 
 #[derive(Debug)]
 pub enum ParseError {
-    MissingChunkInfoData,
-    MissingIndexData,
+    MissingRecord,
     MissingFieldSeparator,
     MissingHeaderOp,
     InvalidOpCode,
     BufferTooSmall,
+    UnexpectedEOF,
     UnexpectedField,
     UnexpectedOpCode,
     MissingField,
+    InvalidBag,
+    UnindexedBag,
 }
 
 impl std::fmt::Display for ParseError {

--- a/frost/src/errors.rs
+++ b/frost/src/errors.rs
@@ -89,8 +89,7 @@ pub enum ParseError {
 
 impl std::fmt::Display for ParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // Implement display logic
-        write!(f, "Custom error: {:?}", self)
+        write!(f, "Error: {:?}", self)
     }
 }
 

--- a/frost/src/lib.rs
+++ b/frost/src/lib.rs
@@ -843,11 +843,8 @@ fn parse_chunk_info<R: Read + Seek>(
     let chunk_info_header = ChunkInfoHeader::from(header_buf)?;
     let data = get_lengthed_bytes(reader)?;
 
-    let chunk_info_data: Vec<ChunkInfoData> = data
-        .windows(8)
-        .step_by(8)
-        .flat_map(ChunkInfoData::from)
-        .collect();
+    let chunk_info_data: Vec<ChunkInfoData> =
+        data.chunks_exact(8).flat_map(ChunkInfoData::from).collect();
 
     if chunk_info_data.len() != chunk_info_header.connection_count as usize {
         eprintln!("missing chunk info data");
@@ -866,8 +863,7 @@ fn parse_index<R: Read + Seek>(
     let data = get_lengthed_bytes(reader)?;
 
     let index_data: Vec<IndexData> = data
-        .windows(12)
-        .step_by(12)
+        .chunks_exact(12)
         .flat_map(|buf| IndexData::from(buf, chunk_header_pos, index_data_header.connection_id))
         .collect();
 

--- a/frost/src/util/msgs.rs
+++ b/frost/src/util/msgs.rs
@@ -1,10 +1,8 @@
-use std::borrow::Cow;
-
 use serde;
 use serde::de;
 use serde_rosmsg;
 
-use crate::errors::{Error, ErrorKind};
+use crate::errors::Error;
 use crate::{ChunkHeaderLoc, DecompressedBag};
 
 pub trait Msg {}
@@ -19,21 +17,17 @@ pub struct MessageView<'a> {
 
 impl<'a> MessageView<'a> {
     /// Returns the raw bytes of the entire Chunk that holds the message
-    fn chunk_bytes(&self) -> Result<&'a [u8], Error> {
+    fn chunk_bytes(&self) -> &'a [u8] {
         self.bag
             .chunk_bytes
             .get(&self.chunk_loc)
             .map(|vec| vec.as_slice())
-            .ok_or_else(|| {
-                Error::new(ErrorKind::InvalidBag(Cow::Borrowed(
-                    "Supplied chunk loc for msg view doesn't exist",
-                )))
-            })
+            .expect("this function is only possible to be called on a bag with chunks populated")
     }
 
     /// Returns the raw bytes of the entire ROS message
     pub fn raw_bytes(&self) -> Result<&'a [u8], Error> {
-        Ok(&self.chunk_bytes()?[self.start_index..self.end_index])
+        Ok(&self.chunk_bytes()[self.start_index..self.end_index])
     }
 
     /// Turns a `MessageView` into a Rust struct

--- a/frost/src/util/parsing.rs
+++ b/frost/src/util/parsing.rs
@@ -1,4 +1,4 @@
-use std::io::{self, Read};
+use std::io::Read;
 
 use crate::errors::ParseError;
 

--- a/frost/src/util/parsing.rs
+++ b/frost/src/util/parsing.rs
@@ -1,63 +1,65 @@
 use std::io::{self, Read};
 
+use crate::errors::ParseError;
+
 #[inline(always)]
-pub fn parse_u8(buf: &[u8]) -> io::Result<u8> {
+pub fn parse_u8(buf: &[u8]) -> Result<u8, ParseError> {
     parse_u8_at(buf, 0)
 }
 
 #[inline(always)]
-pub fn parse_u8_at(buf: &[u8], index: usize) -> io::Result<u8> {
+pub fn parse_u8_at(buf: &[u8], index: usize) -> Result<u8, ParseError> {
     let bytes = buf.get(index..index + 1).ok_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "Buffer is not large enough to parse 1 bytes",
-        )
+        eprintln!("Buffer is not large enough to parse 1 byte");
+        ParseError::BufferTooSmall
     })?;
     Ok(u8::from_le_bytes(bytes.try_into().unwrap()))
 }
 
 #[inline(always)]
-pub fn parse_le_u32(buf: &[u8]) -> io::Result<u32> {
+pub fn parse_le_u32(buf: &[u8]) -> Result<u32, ParseError> {
     parse_le_u32_at(buf, 0)
 }
 
 #[inline(always)]
-pub fn parse_le_u32_at(buf: &[u8], index: usize) -> io::Result<u32> {
+pub fn parse_le_u32_at(buf: &[u8], index: usize) -> Result<u32, ParseError> {
     let bytes = buf.get(index..index + 4).ok_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "Buffer is not large enough to parse 4 bytes",
-        )
+        eprintln!("Buffer is not large enough to parse 4 bytes");
+        ParseError::BufferTooSmall
     })?;
     Ok(u32::from_le_bytes(bytes.try_into().unwrap()))
 }
 
 #[inline(always)]
-pub fn parse_le_u64(buf: &[u8]) -> io::Result<u64> {
+pub fn parse_le_u64(buf: &[u8]) -> Result<u64, ParseError> {
     parse_le_u64_at(buf, 0)
 }
 
 #[inline(always)]
-pub fn parse_le_u64_at(buf: &[u8], index: usize) -> io::Result<u64> {
+pub fn parse_le_u64_at(buf: &[u8], index: usize) -> Result<u64, ParseError> {
     let bytes = buf.get(index..index + 8).ok_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "Buffer is not large enough to parse 8 bytes",
-        )
+        eprintln!("Buffer is not large enough to parse 8 bytes");
+        ParseError::BufferTooSmall
     })?;
     Ok(u64::from_le_bytes(bytes.try_into().unwrap()))
 }
 
 #[inline(always)]
-pub fn get_lengthed_bytes(reader: &mut impl Read) -> io::Result<Vec<u8>> {
+pub fn get_lengthed_bytes(reader: &mut impl Read) -> Result<Vec<u8>, ParseError> {
     // Get a vector of bytes from a reader when the first 4 bytes are the length
     // Ex: with <header_len><header> or <data_len><data>, this function returns either header or data
     let mut len_buf = [0u8; 4];
-    reader.read_exact(&mut len_buf)?;
+    reader.read_exact(&mut len_buf).map_err(|e| {
+        eprintln!("could not read the 4 byte length field, not enough bytes {e}");
+        ParseError::BufferTooSmall
+    })?;
 
     let len = u32::from_le_bytes(len_buf);
     let mut bytes = vec![0u8; len as usize];
-    reader.read_exact(&mut bytes)?;
+    reader.read_exact(&mut bytes).map_err(|e| {
+        eprintln!("could not read the supplied length of {len}, not enough bytes {e}");
+        ParseError::BufferTooSmall
+    })?;
 
     Ok(bytes)
 }

--- a/frost/src/util/time.rs
+++ b/frost/src/util/time.rs
@@ -3,6 +3,8 @@ use std::{io, time::Duration};
 
 use chrono::{DateTime, TimeZone, Utc};
 
+use crate::errors::ParseError;
+
 use super::parsing;
 
 pub const MIN: Time = Time { secs: 0, nsecs: 1 };
@@ -60,7 +62,7 @@ impl Time {
     fn new(secs: u32, nsecs: u32) -> Time {
         Time { secs, nsecs }
     }
-    pub fn from(buf: &[u8]) -> io::Result<Time> {
+    pub fn from(buf: &[u8]) -> Result<Time, ParseError> {
         let secs = parsing::parse_le_u32(buf)?;
         let nsecs = parsing::parse_le_u32_at(buf, 4)?;
         Ok(Time { secs, nsecs })

--- a/frost/src/util/time.rs
+++ b/frost/src/util/time.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::{io, time::Duration};
+use std::time::Duration;
 
 use chrono::{DateTime, TimeZone, Utc};
 


### PR DESCRIPTION
Updates the parsing code to have simple unit variant errors in the hot loop, speeding up bag reading by ~100ms (573ms -> 430ms).
Other updates:
- Fixes https://github.com/dantheman3333/frost/issues/33 by using `chunks_exact` for a code generation fix
- Fixes benches that were not using the new `DecompressedBag` api
- New 0.4.1 release