### PR TITLE
Add into iter bound for Query topics/types

### DIFF
--- a/examples/read_bag/src/main.rs
+++ b/examples/read_bag/src/main.rs
@@ -46,7 +46,7 @@ fn main() {
         }
     }
 
-    let query = Query::new().with_topics(&["/chatter"]);
+    let query = Query::new().with_topics(["/chatter"]);
     let count = bag.read_messages(&query).unwrap().count();
     assert_eq!(count, 100);
 
@@ -54,7 +54,7 @@ fn main() {
     let msg = msg_view.instantiate::<std_msgs::String>().unwrap();
     println!("Last {} message is {}", &msg_view.topic, msg.data);
 
-    let query = Query::new().with_types(&["std_msgs/Float64MultiArray"]);
+    let query = Query::new().with_types(["std_msgs/Float64MultiArray"]);
     let count = bag.read_messages(&query).unwrap().count();
     assert_eq!(count, 100);
     println!(

--- a/frost/Cargo.toml
+++ b/frost/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frost"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 rust-version = "1.65"
 build = "build.rs"

--- a/frost/src/util/query.rs
+++ b/frost/src/util/query.rs
@@ -217,5 +217,9 @@ mod tests {
 
         let query = Query::new().with_topics(topics);
         assert_equal(sorted(query.topics.unwrap()), ["/array", "/chatter"]);
+
+        let topics = vec!["/chatter".to_string(), "/array".to_string()];
+        let query = Query::new().with_topics(&topics);
+        assert_equal(sorted(query.topics.unwrap()), ["/array", "/chatter"]);
     }
 }


### PR DESCRIPTION
Makes a more user friendly api for adding topics and types to a Query
Bumps frost to 0.4.2